### PR TITLE
Prevents error when property is not defined

### DIFF
--- a/code/Populate.php
+++ b/code/Populate.php
@@ -39,7 +39,7 @@ class Populate
      *
      * @var array
      */
-    private static $truncate_classes = [];
+    private static $truncate_objects = [];
 
     /**
      * @config


### PR DESCRIPTION
This property name was changed in a previous commit w/o changing the references to it in other sections of the code.